### PR TITLE
Look up pointer and value receiver methods

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -353,10 +353,16 @@ func callMethodFromTag[T any](structVal reflect.Value, field reflect.StructField
 		return val, false
 	}
 
-	method := structVal.MethodByName(methodName)
+	// Try to get the method from the struct
+	// We look for pointer receiver method first, then value receivers
+	// We it in this order under the assumption that people usually use pointer receivers
+	method := structVal.Addr().MethodByName(methodName)
 	if !method.IsValid() {
-		println("no method found: ", methodName, field.Name, structVal.Type().String())
-		return val, false
+		method = structVal.MethodByName(methodName)
+		if !method.IsValid() {
+			println("no method found: ", methodName, field.Name, structVal.Type().String())
+			return val, false
+		}
 	}
 
 	methodType := method.Type()

--- a/tags_test.go
+++ b/tags_test.go
@@ -572,7 +572,8 @@ type methodStruct struct {
 	FloatField5 float64 `fuzz-float-method:"FloatOptions"`
 }
 
-func (s methodStruct) StringOptions() []string {
+// Pointer receiver method
+func (s *methodStruct) StringOptions() []string {
 	return []string{
 		"zero",
 		"one",
@@ -583,6 +584,7 @@ func (s methodStruct) StringOptions() []string {
 	}
 }
 
+// Value receiver method
 func (s methodStruct) IntOptions() []int64 {
 	return []int64{
 		0,
@@ -594,7 +596,8 @@ func (s methodStruct) IntOptions() []int64 {
 	}
 }
 
-func (s methodStruct) UintOptions() []uint64 {
+// Pointer receiver method
+func (s *methodStruct) UintOptions() []uint64 {
 	return []uint64{
 		0,
 		10,
@@ -605,6 +608,7 @@ func (s methodStruct) UintOptions() []uint64 {
 	}
 }
 
+// Value receiver method
 func (s methodStruct) FloatOptions() []float64 {
 	return []float64{
 		0.0,


### PR DESCRIPTION
This makes the method lookup more reliable.

In the future many of the debug print statements will turn into errors which should stop the test from running. As it is, if you make a mistake in your tags the test will run and not do what you expected. This feels like an extremely bad user-experience, the case where your tests are passing but not actually testing what you think is a nightmare.