### PR TITLE
Adding stack fuzz example

### DIFF
--- a/examples/stack/.gitignore
+++ b/examples/stack/.gitignore
@@ -1,0 +1,1 @@
+testdata/

--- a/examples/stack/fuzz_test.go
+++ b/examples/stack/fuzz_test.go
@@ -1,0 +1,59 @@
+package stack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/fmstephe/fuzzhelper"
+)
+
+const (
+	pushOp = "push"
+	popOp  = "pop"
+)
+
+// StackFuzzStep is used to construct a series of push or pop operations
+// for fuzzing test runs
+type StackFuzzStep struct {
+	Operation string `fuzz-string-method:"AllOperations"`
+	PushValue string `fuzz-string-range:"1,10"`
+	nextStep  *StackFuzzStep
+}
+
+// List of operations which we allow to execute at each step
+func (s StackFuzzStep) AllOperations() []string {
+	return []string{
+		pushOp,
+		popOp,
+	}
+}
+
+// Using StackFuzzStep we stress test the Stack with a random series of push/pop operations
+func FuzzStack(f *testing.F) {
+	f.Fuzz(func(t *testing.T, bytes []byte) {
+		stack := New()
+		step := &StackFuzzStep{}
+		c := fuzzhelper.NewByteConsumer(bytes)
+		fuzzhelper.Fill(step, c)
+		count := 0
+
+		defer func() {
+			if p := recover(); p != nil {
+				// recover a panic and add some extra information for debugging
+				panic(fmt.Errorf("Panic stack{%s} steps: %d, %s", stack, count, p))
+			}
+		}()
+
+		for step != nil {
+			count++
+			switch step.Operation {
+			case pushOp:
+				stack.Push(step.PushValue)
+			case popOp:
+				stack.Pop()
+			default:
+				panic(fmt.Errorf("unknown operation: %d: %q", count, step.Operation))
+			}
+		}
+	})
+}

--- a/examples/stack/stack.go
+++ b/examples/stack/stack.go
@@ -1,0 +1,37 @@
+package stack
+
+import "fmt"
+
+type Stack struct {
+	top  int16 // This will cause bugs on overflow
+	data []any
+}
+
+func New() *Stack {
+	return &Stack{
+		data: []any{},
+	}
+}
+
+func (s *Stack) Push(val any) {
+	s.top++
+	if len(s.data) < int(s.top) {
+		s.data = append(s.data, val)
+	} else {
+		s.data[s.top-1] = val
+	}
+}
+
+func (s *Stack) Pop() any {
+	if s.top == 0 {
+		return nil
+	}
+
+	val := s.data[s.top-1]
+	s.top--
+	return val
+}
+
+func (s *Stack) String() string {
+	return fmt.Sprintf("top: %d, data-length: %d", s.top, len(s.data))
+}

--- a/examples/stack/stack_test.go
+++ b/examples/stack/stack_test.go
@@ -1,0 +1,60 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStack_PopEmpty(t *testing.T) {
+	s := New()
+
+	// Popping when the stack is empty produces nil
+	assert.Nil(t, s.Pop())
+}
+
+func TestStack_PushPop(t *testing.T) {
+	s := New()
+
+	// Popping when the stack is empty produces nil
+	assert.Nil(t, s.Pop())
+
+	s.Push("foo")
+	val := s.Pop()
+	assert.Equal(t, "foo", val)
+
+	// Popping when the stack is empty produces nil
+	assert.Nil(t, s.Pop())
+}
+
+func TestStack_PushPushPopPop(t *testing.T) {
+	s := New()
+
+	// Popping when the stack is empty produces nil
+	assert.Nil(t, s.Pop())
+
+	s.Push("foo")
+	s.Push("bar")
+	assert.Equal(t, "bar", s.Pop())
+	assert.Equal(t, "foo", s.Pop())
+
+	// Popping when the stack is empty produces nil
+	assert.Nil(t, s.Pop())
+}
+
+func TestStack_PushPushPopPushPopPop(t *testing.T) {
+	s := New()
+
+	// Popping when the stack is empty produces nil
+	assert.Nil(t, s.Pop())
+
+	s.Push("foo")
+	s.Push("bar")
+	assert.Equal(t, "bar", s.Pop())
+	s.Push("bang")
+	assert.Equal(t, "bang", s.Pop())
+	assert.Equal(t, "foo", s.Pop())
+
+	// Popping when the stack is empty produces nil
+	assert.Nil(t, s.Pop())
+}


### PR DESCRIPTION
Here we implement a stack implementation which passes a small set of reasonable looking tests. The stack implementation has a problem where the integer which tracks the top position of the stack is only 16 bits wide and will overflow under fairly normal usage conditions. However the conditions are difficult to hit in conventional unit tests.

We add a fuzzing test which will reliably uncover the overflow failure condition. A user should be able to run

go test -fuzz=Fuzz

and see a failing case very quickly.

Adding comments to fuzz_test.go for stack